### PR TITLE
Reuse Moshi's generated option for convenience

### DIFF
--- a/moshi-sealed-codegen/src/main/kotlin/dev/zacsweers/moshisealed/codegen/MoshiSealedProcessor.kt
+++ b/moshi-sealed-codegen/src/main/kotlin/dev/zacsweers/moshisealed/codegen/MoshiSealedProcessor.kt
@@ -74,8 +74,10 @@ class MoshiSealedProcessor : AbstractProcessor() {
      * Note that this can only be one of the following values:
      *   * `"javax.annotation.processing.Generated"` (JRE 9+)
      *   * `"javax.annotation.Generated"` (JRE <9)
+     *
+     * We reuse Moshi's option for convenience so you don't have to declare multiple options.
      */
-    const val OPTION_GENERATED = "moshisealed.generated"
+    const val OPTION_GENERATED = "moshi.generated"
     private val POSSIBLE_GENERATED_NAMES = setOf(
         "javax.annotation.processing.Generated",
         "javax.annotation.Generated"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
 kapt {
   arguments {
-    arg("moshisealed.generated", "javax.annotation.Generated")
+    arg("moshi.generated", "javax.annotation.Generated")
   }
 }
 


### PR DESCRIPTION
This prevents consumers from having to redeclare the option